### PR TITLE
To fix external Volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,6 @@ RUN	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C &
 ADD files /
 RUN	chmod -R +x /etc/my_init.d /etc/service && \
 	chmod 644 /etc/cron.d/librenms
+	chmod 755 -R /opt/librenms/rrd
 
 VOLUME ["/opt/librenms/logs", "/opt/librenms/rrd", "/etc/nginx/ssl", "/var/log/nginx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C &
 
 ADD files /
 RUN	chmod -R +x /etc/my_init.d /etc/service && \
-	chmod 644 /etc/cron.d/librenms
+	chmod 644 /etc/cron.d/librenms && \
 	chmod 755 -R /opt/librenms/rrd
 
 VOLUME ["/opt/librenms/logs", "/opt/librenms/rrd", "/etc/nginx/ssl", "/var/log/nginx"]


### PR DESCRIPTION
Without changing permissions to 755 for rrd directory, rrd data cannot be written to external volume, outside of docker container on Synology NAS.