### PR TITLE
Add Nagios Plugins support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C &
 		imagemagick \
 		whois \
 		mtr-tiny \
+		nagios-plugins\
 		nmap \
 		python-mysqldb \
 		rrdtool \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C C300EE8C &
 		imagemagick \
 		whois \
 		mtr-tiny \
-		nagios-plugins\
+		nagios-plugins \
 		nmap \
 		python-mysqldb \
 		rrdtool \

--- a/files/opt/librenms/config.php
+++ b/files/opt/librenms/config.php
@@ -15,6 +15,8 @@ $config['enable_billing'] = 1;
 $config['show_services'] = 1;
 $config['update'] = 0;
 
+$config['nagios_plugins']   = "/usr/lib/nagios/plugins"
+
 $config['memcached']['enable'] = filter_var(getenv('MEMCACHED_ENABLE'), FILTER_VALIDATE_BOOLEAN);
 $config['memcached']['host'] = getenv('MEMCACHED_HOST');
 $config['memcached']['port'] = getenv('MEMCACHED_PORT') ?: 11211;


### PR DESCRIPTION
As LibreNMS supports Nagios plugins for service checks, why not include them by default as config file itself has $config['show_services'] = 1; statement already included. Why not make it actually usable out of the box?
Despite the fact that we are running in container, as they require less than 3,5MBytes of space