### PR TITLE
Bug Fix for configurable mysql port

### DIFF
--- a/files/etc/my_init.d/5_environment
+++ b/files/etc/my_init.d/5_environment
@@ -13,6 +13,7 @@ function addConfig() {
 }
 
 addConfig DB_HOST
+addConfig DB_PORT
 addConfig DB_USER
 addConfig DB_PASS
 addConfig DB_NAME


### PR DESCRIPTION
Variable DB_PORT has to be exported too, or cronjobs will fail to update database.