### PR TITLE
Updated bad interface regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ config.interfaces.php:
 ```
 <?php
 
-$config['bad_if_regexp'][] = '/^docker[\w]+$/';
+$config['bad_if_regexp'][] = '/^docker[-\w].*$/';
 $config['bad_if_regexp'][] = '/^lxcbr[0-9]+$/';
 $config['bad_if_regexp'][] = '/^veth.*$/';
 $config['bad_if_regexp'][] = '/^virbr.*$/';


### PR DESCRIPTION
As I discovered, docker can spawn interfaces which current regex does not match, hence the small change to match these too.