### PR TITLE
Fix for cron patterns containing slashes

### DIFF
--- a/files/etc/my_init.d/0_cron
+++ b/files/etc/my_init.d/0_cron
@@ -46,7 +46,7 @@ else
 fi
 
 if [ "$SNMP_SCAN_ENABLE" = "true" ]; then
-	sed -i "s/PLACEHOLDER_CRON/$SNMP_SCAN_CRON/g" /etc/librenms/cron/snmp-scan
+	sed -i "s@PLACEHOLDER_CRON@$SNMP_SCAN_CRON@g" /etc/librenms/cron/snmp-scan
 	ln -sf /etc/librenms/cron/snmp-scan /etc/cron.d/snmp-scan
 fi
 


### PR DESCRIPTION
if $SNMP_SCAN_CRON contains a cron expression with slashes the start of the container fails.