### PR TITLE
Added support for DB_PASS_FILE to use secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The following keys can be passed directly via the -e switch:
 |DB_NAME                 |                                      |MySQL database name
 |DB_USER                 |                                      |MySQL user
 |DB_PASS                 |                                      |MySQL password
+|DB_PASS_FILE            |                                      |MySQL password via secret
 |TZ                      |UTC                                   |Timezone (e.g. Europe/Zurich)
 
 ### Enabling/disabling container features

--- a/files/etc/my_init.d/4_config
+++ b/files/etc/my_init.d/4_config
@@ -9,7 +9,9 @@ function requireConfig() {
 
 requireConfig DB_HOST
 requireConfig DB_USER
-requireConfig DB_PASS
+if [ -z DB_PASS_FILE]; then
+    requireConfig DB_PASS
+fi
 requireConfig DB_NAME
 requireConfig BASE_URL
 

--- a/files/etc/my_init.d/5_environment
+++ b/files/etc/my_init.d/5_environment
@@ -16,6 +16,7 @@ addConfig DB_HOST
 addConfig DB_PORT
 addConfig DB_USER
 addConfig DB_PASS
+addConfig DB_PASS_FILE
 addConfig DB_NAME
 addConfig BASE_URL
 addConfig MEMCACHED_ENABLE

--- a/files/opt/librenms/config.php
+++ b/files/opt/librenms/config.php
@@ -3,7 +3,11 @@
 $config['db_host'] = getenv('DB_HOST');
 $config['db_port'] = intval(getenv('DB_PORT') ?: 3306);
 $config['db_user'] = getenv('DB_USER');
-$config['db_pass'] = getenv('DB_PASS');
+if (getenv('DB_PASS_FILE')) {
+    $config['db_pass'] = file_get_contents(getenv('DB_PASS_FILE'));
+} else {
+    $config['db_pass'] = getenv('DB_PASS');
+}
 $config['db_name'] = getenv('DB_NAME');
 $config['db']['extension'] = 'mysqli';
 


### PR DESCRIPTION
This is untested.

Added support for passing DB_PASS_FILE so that you can use secrets (https://docs.docker.com/engine/swarm/secrets/).