### PR TITLE
Added missing trim() to DB_PASS_FILE env

### DIFF
--- a/files/opt/librenms/config.php
+++ b/files/opt/librenms/config.php
@@ -4,7 +4,7 @@ $config['db_host'] = getenv('DB_HOST');
 $config['db_port'] = intval(getenv('DB_PORT') ?: 3306);
 $config['db_user'] = getenv('DB_USER');
 if (getenv('DB_PASS_FILE')) {
-    $config['db_pass'] = file_get_contents(getenv('DB_PASS_FILE'));
+    $config['db_pass'] = trim(file_get_contents(getenv('DB_PASS_FILE')));
 } else {
     $config['db_pass'] = getenv('DB_PASS');
 }


### PR DESCRIPTION
The one issue I'm looking at right now is that `.env` isn't working with this as you need to read the file before setting the env variable for password. Will continue to look.