### PR TITLE
LibreNMS 1.42

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jarischaefer/baseimage-librenms:1.7.1
 
-ARG LIBRENMS_VERSION=1.41
+ARG LIBRENMS_VERSION=1.42
 ENV	TZ=UTC \
 	RRDCACHED_LISTEN=unix:/var/run/rrdcached/rrdcached.sock \
 	RRDCACHED_CONNECT=unix:/var/run/rrdcached/rrdcached.sock \


### PR DESCRIPTION
LibreNMS 1.42 was released.