### PR TITLE
Fix critical error at image start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN	cd /opt && \
 	cd /opt/librenms/html/plugins && \
 	git clone --depth 1 https://github.com/librenms-plugins/Weathermap.git && \
 	cp /opt/librenms/.env.example /opt/librenms/.env && \
+	cd /opt/librenms && php artisan key:generate && \
 	chown -R librenms:librenms /opt/librenms
 
 ADD files /

--- a/files/etc/my_init.d/4_config
+++ b/files/etc/my_init.d/4_config
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /opt/librenms/.env
+
 function requireConfig() {
 	if [ -z ${!1} ]; then
 		echo "Error: $1 is unset"


### PR DESCRIPTION
- Added call to php artisan key:generate in dockerfile to init APP_KEY in .env
- Change 4_config to source .env file

This is done to get the image to start.

Now it stops with the error:
Error: APP_KEY is unset
*** /etc/my_init.d/4_config failed with status 1
